### PR TITLE
build(#79): use conventional commit messages for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/playwright/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build" # Conventional Commits type, e.g. build(deps): bump ...
+      include: "scope" # Adds (deps) / (deps-dev) scope


### PR DESCRIPTION
Add the commit-message block to the npm updates entry so Dependabot titles its commits `build(deps): bump ...` / `build(deps-dev): bump ...`, matching the backend and frontend repos.